### PR TITLE
Expose hidden date filter parameters in get_notes_advanced MCP tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -479,6 +479,41 @@ class BearMCPServer {
               items: { type: 'string' },
               description: 'Tags to exclude from results',
             },
+            dateFrom: {
+              type: 'string',
+              description: 'Filter notes created on or after this date (inclusive) (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)',
+            },
+            dateTo: {
+              type: 'string',
+              description: 'Filter notes created on or before this date (inclusive) (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)',
+            },
+
+            modifiedAfter: {
+              type: 'string',
+              description: 'Filter notes modified on or after this date (inclusive) (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)',
+            },
+            modifiedBefore: {
+              type: 'string',
+              description: 'Filter notes modified on or before this date (inclusive) (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)',
+            },
+
+            includeContent: {
+              type: 'boolean',
+              description: 'Include full content in results (default: true for preview)',
+            },
+
+            includeTrashed: {
+              type: 'boolean',
+              description: 'Include trashed notes in results (default: false)',
+            },
+            includeArchived: {
+              type: 'boolean',
+              description: 'Include archived notes in results (default: false)',
+            },
+            includeEncrypted: {
+              type: 'boolean',
+              description: 'Include encrypted notes in results (default: false)',
+            },
             sortBy: {
               type: 'string',
               enum: ['created', 'modified', 'title', 'size'],
@@ -494,6 +529,11 @@ class BearMCPServer {
               description: 'Maximum number of results',
               minimum: 1,
               maximum: 100,
+            },
+            offset: {
+              type: 'number',
+              description: 'Number of results to skip for pagination',
+              minimum: 0,
             },
           },
           required: [],
@@ -1399,9 +1439,18 @@ ${isRunning ? '✅ Write operations use sync-safe Bear API' : '✅ All database 
         query: args?.query,
         tags: args?.tags,
         excludeTags: args?.excludeTags,
+        dateFrom: args?.dateFrom ? new Date(args.dateFrom) : undefined,
+        dateTo: args?.dateTo ? new Date(args.dateTo) : undefined,
+        modifiedAfter: args?.modifiedAfter ? new Date(args.modifiedAfter) : undefined,
+        modifiedBefore: args?.modifiedBefore ? new Date(args.modifiedBefore) : undefined,
+        includeContent: args?.includeContent,
+        includeTrashed: args?.includeTrashed,
+        includeArchived: args?.includeArchived,
+        includeEncrypted: args?.includeEncrypted,
         sortBy: args?.sortBy || 'modified',
         sortOrder: args?.sortOrder || 'desc',
         limit: args?.limit || 20,
+        offset: args?.offset,
       };
 
       const notes = await this.bearService.getNotesAdvanced(options);


### PR DESCRIPTION
# Expose Hidden Search Parameters in get_notes_advanced

## Problem
The `get_notes_advanced` MCP tool had several useful filtering parameters implemented in the `BearService` class but not exposed through the MCP interface schema. This meant that MCP clients could not access advanced filtering capabilities that were already fully functional.

## Solution
This PR exposes the following previously hidden parameters in the MCP tool schema:

### Date Range Filters
- **`dateFrom`**: Filter notes created on or after this date (inclusive, `>=` operator)
- **`dateTo`**: Filter notes created on or before this date (inclusive, `<=` operator)  
- **`modifiedAfter`**: Filter notes modified on or after this date (inclusive, `>=` operator)
- **`modifiedBefore`**: Filter notes modified on or before this date (inclusive, `<=` operator)

### Inclusion Flags
- **`includeContent`**: Include full content in results
- **`includeTrashed`**: Include trashed notes in results
- **`includeArchived`**: Include archived notes in results
- **`includeEncrypted`**: Include encrypted notes in results

### Pagination
- **`offset`**: Number of results to skip for pagination support

## Implementation Details
- **No logic changes**: All functionality was already implemented in `BearService.getNotesAdvanced()`
- **Interface-only update**: Only the MCP tool schema and TypeScript interfaces were updated
- **Backward compatible**: Existing calls continue to work unchanged
- **Inclusive boundaries**: Date filters include the specified boundary dates (using `>=` and `<=` SQL operators)

## Usage Examples

```json
{
  "dateFrom": "2024-01-01",
  "dateTo": "2024-01-31", 
  "modifiedAfter": "2024-01-15",
  "includeArchived": true,
  "offset": 20,
  "limit": 10
}
```

## Benefits
- **Enhanced filtering**: MCP clients can now access comprehensive date-based filtering
- **Better pagination**: Full pagination support with offset parameter
- **Granular control**: Fine-grained control over which note types to include
- **No breaking changes**: Maintains full backward compatibility

This change makes the `get_notes_advanced` tool significantly more powerful for MCP clients while requiring no changes to existing integrations.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1761628396840049 -->
